### PR TITLE
Add optional CLI feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,7 @@ path = "src/main.rs"
 
 [dependencies]
 
+[features]
+cli = []
+
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ The binary will be available at `target/release/seqrush`.
 seqrush -s sequences.fasta -o graph.gfa
 ```
 
+Enable the optional `cli` feature to use command-line flags.
+
 ### Advanced Options
 
 ```bash

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,43 @@
+#[cfg(feature = "cli")]
+use seqrush::Args;
+
+#[cfg(feature = "cli")]
+/// Parse command line arguments into `Args`.
+pub fn parse() -> Args {
+    let mut sequences = None;
+    let mut output = None;
+    let mut threads = 1_usize;
+    let mut min_match_length = 15_usize;
+
+    let mut iter = std::env::args().skip(1);
+    while let Some(arg) = iter.next() {
+        match arg.as_str() {
+            "-s" | "--sequences" => sequences = iter.next(),
+            "-o" | "--output" => output = iter.next(),
+            "-t" | "--threads" => {
+                if let Some(t) = iter.next() {
+                    if let Ok(v) = t.parse() {
+                        threads = v;
+                    }
+                }
+            }
+            "-k" | "--min-match-length" => {
+                if let Some(m) = iter.next() {
+                    if let Ok(v) = m.parse() {
+                        min_match_length = v;
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    let sequences = sequences.expect("input FASTA required");
+    let output = output.expect("output file required");
+    Args {
+        sequences,
+        output,
+        threads,
+        min_match_length,
+    }
+}
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,15 +1,26 @@
 use seqrush::seqrush::{Args, run_seqrush};
 
+#[cfg(feature = "cli")]
+mod cli;
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut iter = std::env::args().skip(1);
-    let sequences = iter.next().expect("input FASTA required");
-    let output = iter.next().expect("output file required");
-    let args = Args {
-        sequences,
-        output,
-        threads: 1,
-        min_match_length: 15,
+    #[cfg(feature = "cli")]
+    let args = cli::parse();
+
+    #[cfg(not(feature = "cli"))]
+    let args = {
+        let mut iter = std::env::args().skip(1);
+        let sequences = iter.next().expect("input FASTA required");
+        let output = iter.next().expect("output file required");
+        Args {
+            sequences,
+            output,
+            threads: 1,
+            min_match_length: 15,
+        }
     };
+
     run_seqrush(args)?;
     Ok(())
 }
+

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -41,3 +41,28 @@ fn run_seqrush_writes_output() {
     let content = fs::read_to_string(out_path).unwrap();
     assert!(content.starts_with("H\tVN:Z:1.0"));
 }
+
+#[cfg(feature = "cli")]
+#[test]
+fn cli_parses_flags() {
+    use std::process::Command;
+    let in_path = temp_file("cli_in");
+    let mut f = File::create(&in_path).unwrap();
+    writeln!(f, ">z\nAAAA").unwrap();
+    f.sync_all().unwrap();
+    let out_path = temp_file("cli_out");
+    let status = Command::new(env!("CARGO_BIN_EXE_seqrush"))
+        .args([
+            "-s",
+            in_path.to_str().unwrap(),
+            "-o",
+            out_path.to_str().unwrap(),
+            "-t",
+            "2",
+            "-k",
+            "5",
+        ])
+        .status()
+        .unwrap();
+    assert!(status.success());
+}


### PR DESCRIPTION
## Summary
- add optional `cli` feature for a simple argument parser
- support `-s`, `-o`, `-t`, and `-k` flags
- document optional CLI usage
- test command line parsing

## Testing
- `cargo test --features cli`


------
https://chatgpt.com/codex/tasks/task_e_6869c0180d3883339629c4ab89e5fe88