### PR TITLE
Add AGENTS guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+# AGENTS
+
+Developers should:
+
+1. Format code using `cargo fmt`.
+2. Run `cargo clippy -- -D warnings`.
+3. Run `cargo test`.
+
+Follow these steps before opening a PR.

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -1,0 +1,4 @@
+# AGENTS
+
+Rust library code lives here. Keep modules small and document
+public functions with rustdoc comments.

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,0 +1,3 @@
+# AGENTS
+
+Integration tests for the crate. Run `cargo test` to execute.


### PR DESCRIPTION
## Summary
- add AGENTS guideline at project root
- add brief AGENTS notes for src and tests directories

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6869c0b2e3388333a8664ba8356c4a7f