### PR TITLE
Fix main import path

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use seqrush::seqrush::{Args, run_seqrush};
+use seqrush::{Args, run_seqrush};
 
 #[cfg(feature = "cli")]
 mod cli;


### PR DESCRIPTION
## Summary
- use re-exported `Args` and `run_seqrush`

## Testing
- `cargo test`
- `cargo fmt` *(fails: component missing)*
- `cargo clippy -- -D warnings` *(fails: component missing)*

------
https://chatgpt.com/codex/tasks/task_e_6869c7606f608333b4a7a99a130b96b7