### PR TITLE
Update CLI build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ cd seqrush
 cargo build --release
 ```
 
+To use the CLI flags, build the binary with the `cli` feature enabled:
+
+```bash
+cargo build --release --features cli
+```
+
 The binary will be available at `target/release/seqrush`.
 
 ## Usage


### PR DESCRIPTION
## Summary
- update the README build instructions to mention the `cli` feature flag

## Testing
- `cargo test`
- `cargo clippy -- -D warnings` *(fails: `cargo-clippy` is not installed)*
- `cargo fmt` *(fails: `cargo-fmt` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6869c774dfe48333bffaed14f4d39161