### PR TITLE
Add formatting and lint checks to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,10 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Check formatting
+        run: cargo fmt -- --check
+      - name: Lint with Clippy
+        run: cargo clippy -- -D warnings
       - name: Run tests
         run: cargo test --verbose
       - name: Generate coverage


### PR DESCRIPTION
## Summary
- ensure CI checks `cargo fmt` formatting
- enforce lint warnings with `cargo clippy`

## Testing
- `cargo fmt`
- `cargo clippy`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6869c77756508333aa960f317bbd547a