### PR TITLE
Refactor load_sequences to stream FASTA

### DIFF
--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -60,6 +60,19 @@ fn load_sequences_missing_file() {
 }
 
 #[test]
+fn load_sequences_large_input() {
+    let path = temp_file("large");
+    let mut f = File::create(&path).unwrap();
+    for i in 0..1000 {
+        writeln!(f, ">{}\nACGTACGTACGTACGTACGTACGTACGTACGT", i).unwrap();
+    }
+    f.sync_all().unwrap();
+    let seqs = load_sequences(path.to_str().unwrap()).unwrap();
+    assert_eq!(seqs.len(), 1000);
+    fs::remove_file(path).unwrap();
+}
+
+#[test]
 fn run_seqrush_missing_input() {
     let out_path = temp_file("out_missing");
     let args = Args {


### PR DESCRIPTION
## Summary
- avoid loading entire FASTA file into memory
- add integration test for large FASTA parsing

## Testing
- `cargo fmt` *(fails: 'cargo-fmt' is not installed)*
- `cargo clippy -- -D warnings` *(fails: 'cargo-clippy' is not installed)*
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6869c787204c8333814114d8470b8868