### PR TITLE
Update run_seqrush links

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,11 @@ pub mod seqrush {
                 .collect::<Vec<_>>()
                 .join(",");
             writeln!(file, "P\tp1\t{}\t*", path_line)?;
-            writeln!(file, "L\t{}\t+\t{}\t+\t0M", sequences[0].id, sequences[1].id)?;
+            for pair in sequences.windows(2) {
+                let a = &pair[0];
+                let b = &pair[1];
+                writeln!(file, "L\t{}\t+\t{}\t+\t0M", a.id, b.id)?;
+            }
         } else if let Some(seq) = sequences.get(0) {
             writeln!(file, "P\tp1\t{}\t*", seq.id)?;
         }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -44,6 +44,27 @@ fn run_seqrush_writes_output() {
     fs::remove_file(&in_path).unwrap();
     fs::remove_file(&out_path).unwrap();
 }
+
+#[test]
+fn run_seqrush_links_multiple_sequences() {
+    let in_path = temp_file("multi_in");
+    let mut f = File::create(&in_path).unwrap();
+    writeln!(f, ">a\nAAAA\n>b\nCCCC\n>c\nGGGG").unwrap();
+    f.sync_all().unwrap();
+    let out_path = temp_file("multi_out");
+    let args = Args {
+        sequences: in_path.to_str().unwrap().to_string(),
+        output: out_path.to_str().unwrap().to_string(),
+        threads: 1,
+        min_match_length: 1,
+    };
+    run_seqrush(args).unwrap();
+    let content = fs::read_to_string(&out_path).unwrap();
+    assert!(content.contains("L\ta\t+\tb\t+\t0M"));
+    assert!(content.contains("L\tb\t+\tc\t+\t0M"));
+    fs::remove_file(&in_path).unwrap();
+    fs::remove_file(&out_path).unwrap();
+}
 #[test]
 fn load_sequences_empty_input() {
     let path = temp_file("empty");


### PR DESCRIPTION
## Summary
- link all adjacent sequences when writing GFA
- add integration test for multiple sequences

## Testing
- `cargo fmt --all` *(fails: component missing)*
- `cargo clippy -- -D warnings` *(fails: component missing)*
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6869c766e2048333a3f6b732ac7b2611