### PR TITLE
Use clap for CLI parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,11 @@ path = "src/lib.rs"
 name = "seqrush"
 path = "src/main.rs"
 
+
 [dependencies]
+clap = { version = "4", features = ["derive"], optional = true }
 
 [features]
-cli = []
+cli = ["clap"]
 
 [dev-dependencies]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,43 +1,38 @@
 #[cfg(feature = "cli")]
+use clap::Parser;
+#[cfg(feature = "cli")]
 use seqrush::Args;
 
 #[cfg(feature = "cli")]
-/// Parse command line arguments into `Args`.
-pub fn parse() -> Args {
-    let mut sequences = None;
-    let mut output = None;
-    let mut threads = 1_usize;
-    let mut min_match_length = 15_usize;
+#[derive(Parser)]
+#[command(name = "seqrush", about = "Build pangenome graphs")] 
+struct CliArgs {
+    /// Input FASTA file
+    #[arg(short = 's', long)]
+    sequences: String,
 
-    let mut iter = std::env::args().skip(1);
-    while let Some(arg) = iter.next() {
-        match arg.as_str() {
-            "-s" | "--sequences" => sequences = iter.next(),
-            "-o" | "--output" => output = iter.next(),
-            "-t" | "--threads" => {
-                if let Some(t) = iter.next() {
-                    if let Ok(v) = t.parse() {
-                        threads = v;
-                    }
-                }
-            }
-            "-k" | "--min-match-length" => {
-                if let Some(m) = iter.next() {
-                    if let Ok(v) = m.parse() {
-                        min_match_length = v;
-                    }
-                }
-            }
-            _ => {}
-        }
-    }
-    let sequences = sequences.expect("input FASTA required");
-    let output = output.expect("output file required");
+    /// Output GFA file
+    #[arg(short = 'o', long)]
+    output: String,
+
+    /// Number of worker threads
+    #[arg(short = 't', long, default_value_t = 1)]
+    threads: usize,
+
+    /// Minimum match length
+    #[arg(short = 'k', long = "min-match-length", default_value_t = 15)]
+    min_match_length: usize,
+}
+
+#[cfg(feature = "cli")]
+/// Parse command line arguments into `Args` using clap.
+pub fn parse() -> Args {
+    let cli = CliArgs::parse();
     Args {
-        sequences,
-        output,
-        threads,
-        min_match_length,
+        sequences: cli.sequences,
+        output: cli.output,
+        threads: cli.threads,
+        min_match_length: cli.min_match_length,
     }
 }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -74,31 +74,32 @@ fn run_seqrush_missing_input() {
 
 use std::process::Command;
 
+#[cfg(feature = "cli")]
 #[test]
 fn cli_no_arguments() {
     let exe = env!("CARGO_BIN_EXE_seqrush");
     let output = Command::new(exe).output().unwrap();
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(stderr.contains("input FASTA required"));
+    assert!(stderr.contains("required arguments"));
 }
 
+#[cfg(feature = "cli")]
 #[test]
 fn cli_missing_output() {
     let exe = env!("CARGO_BIN_EXE_seqrush");
     let output = Command::new(exe)
-        .arg("somefile")
+        .args(["-s", "somefile"]) 
         .output()
         .unwrap();
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(stderr.contains("output file required"));
+    assert!(stderr.contains("required arguments"));
 }
 
 #[cfg(feature = "cli")]
 #[test]
 fn cli_parses_flags() {
-    use std::process::Command;
     let in_path = temp_file("cli_in");
     let mut f = File::create(&in_path).unwrap();
     writeln!(f, ">z\nAAAA").unwrap();


### PR DESCRIPTION
## Summary
- add clap as optional dependency
- migrate CLI to clap parser
- update integration tests for clap messages

## Testing
- `cargo fmt` *(fails: rustfmt not installed)*
- `cargo clippy -- -D warnings` *(fails: clippy not installed)*
- `cargo test --features cli` *(fails: could not fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6869c76f58f8833394e091d265debf0f