### PR TITLE
Add CLI argument parsing test

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,3 +73,6 @@ pub mod seqrush {
 
 pub use seqrush::{load_sequences, run_seqrush, Args, FastaSequence};
 
+#[cfg(feature = "cli")]
+pub mod cli;
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use seqrush::seqrush::{Args, run_seqrush};
 
 #[cfg(feature = "cli")]
-mod cli;
+use seqrush::cli;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     #[cfg(feature = "cli")]

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -1,0 +1,26 @@
+use seqrush::seqrush::Args;
+
+#[cfg(feature = "cli")]
+#[test]
+fn parse_handles_arguments() {
+    // set dummy exe path for cargo to satisfy macros if required
+    std::env::set_var("CARGO_BIN_EXE_seqrush", "dummy");
+    let args = [
+        "binary",
+        "-s",
+        "input.fa",
+        "-o",
+        "out.gfa",
+        "-t",
+        "4",
+        "-k",
+        "20",
+    ];
+    seqrush::cli::set_args_override(args.iter().map(|s| s.to_string()));
+    let parsed = seqrush::cli::parse();
+    seqrush::cli::clear_args_override();
+    assert_eq!(parsed.sequences, "input.fa");
+    assert_eq!(parsed.output, "out.gfa");
+    assert_eq!(parsed.threads, 4);
+    assert_eq!(parsed.min_match_length, 20);
+}


### PR DESCRIPTION
## Summary
- support overriding CLI args for tests
- expose CLI module from the library
- use the new helpers to test argument parsing

## Testing
- `cargo fmt` *(fails: component not installed)*
- `cargo clippy -- -D warnings` *(fails: component not installed)*
- `cargo test`
- `cargo test --features cli` *(fails: test failure)*

------
https://chatgpt.com/codex/tasks/task_e_6869ca888f988333aaa9d7fbc433811e