### PR TITLE
Update default thread count

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Enable the optional `cli` feature to use command-line flags.
 seqrush \
   -s sequences.fasta \        # Input FASTA file
   -o graph.gfa \              # Output GFA file
-  -t 8 \                      # Number of threads (default: 4)
+  -t 8 \                      # Number of threads (default: 1)
   -k 15 \                     # Minimum match length (default: 15)
   --match-score 0 \           # WFA match score (default: 0)
   --mismatch-penalty 5 \      # WFA mismatch penalty (default: 5)


### PR DESCRIPTION
## Summary
- update README to show the default threads is 1

## Testing
- `cargo fmt -- --check` *(fails: rustfmt not installed)*
- `cargo clippy -- -D warnings` *(fails: clippy not installed)*
- `cargo test` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6869e4d35b4c8333833da1a1244b6050