### PR TITLE
Add rust-toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ cat test.gfa
 
 ### Prerequisites
 
-- Rust 1.70 or later
+- Rust via `rustup` (the required version is pinned in `rust-toolchain.toml`)
 - Git
 
 ### Build from Source
@@ -55,6 +55,7 @@ cat test.gfa
 ```bash
 git clone https://github.com/KristopherKubicki/seqrush.git
 cd seqrush
+# rustup will automatically install the toolchain defined in `rust-toolchain.toml`
 cargo build --release
 ```
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.87"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Summary
- pin Rust toolchain version to 1.87 with clippy and rustfmt components
- document pinned toolchain and rustup usage in README

## Testing
- `cargo fmt` *(fails: unsuccessful tunnel)*
- `cargo clippy -- -D warnings` *(fails: unsuccessful tunnel)*
- `cargo test` *(fails: unsuccessful tunnel)*

------
https://chatgpt.com/codex/tasks/task_e_6869e4d8fff48333b0d23593c5fe249e