### PR TITLE
Fix tests to use Vec<&str>

### DIFF
--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -199,12 +199,20 @@ fn run_seqrush_single_sequence_no_links() {
     let content = fs::read_to_string(&gfa_path).unwrap();
     let lines: Vec<&str> = content.lines().collect();
     assert_eq!(lines[0], "H\tVN:Z:1.0");
-    let s_lines: Vec<&&str> = lines.iter().filter(|l| l.starts_with("S\t")).collect();
+    let s_lines: Vec<&str> = lines
+        .iter()
+        .copied()
+        .filter(|l| l.starts_with("S\t"))
+        .collect();
     assert_eq!(s_lines.len(), 1);
-    assert_eq!(s_lines[0], &"S\tid\tACGT");
-    let p_lines: Vec<&&str> = lines.iter().filter(|l| l.starts_with("P\t")).collect();
+    assert_eq!(s_lines[0], "S\tid\tACGT");
+    let p_lines: Vec<&str> = lines
+        .iter()
+        .copied()
+        .filter(|l| l.starts_with("P\t"))
+        .collect();
     assert_eq!(p_lines.len(), 1);
-    assert_eq!(p_lines[0], &"P\tp1\tid\t*");
+    assert_eq!(p_lines[0], "P\tp1\tid\t*");
     assert!(lines.iter().all(|l| !l.starts_with("L\t")));
 
     fs::remove_file(&fasta_path).unwrap();


### PR DESCRIPTION
## Summary
- refactor single sequence integration test to avoid double references

## Testing
- `cargo fmt` *(fails: rustfmt component missing)*
- `cargo clippy -- -D warnings` *(fails: clippy component missing)*
- `cargo test` *(fails: could not download crates)*

------
https://chatgpt.com/codex/tasks/task_e_6869e4ed51148333b11f50947ee3b2dc