### PR TITLE
Document FastaSequence fields

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,9 +14,14 @@ pub mod seqrush {
         pub min_match_length: usize,
     }
 
+    /// Sequence record parsed from a FASTA file.
+    ///
+    /// Contains the identifier and raw sequence bytes for a single entry.
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub struct FastaSequence {
+        /// Identifier without the leading `>` character
         pub id: String,
+        /// Raw nucleotide or amino acid data
         pub data: Vec<u8>,
     }
 


### PR DESCRIPTION
## Summary
- document `FastaSequence` struct and fields

## Testing
- `cargo fmt` *(fails: rustfmt component not installed)*
- `cargo clippy -- -D warnings` *(fails: clippy component not installed)*
- `cargo test` *(fails: could not download crates)*

------
https://chatgpt.com/codex/tasks/task_e_6869e5058e10833383650c3168b09c1e