### PR TITLE
Fix path orientation in single sequence test

### DIFF
--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -204,7 +204,7 @@ fn run_seqrush_single_sequence_no_links() {
     assert_eq!(s_lines[0], &"S\tid\tACGT");
     let p_lines: Vec<&&str> = lines.iter().filter(|l| l.starts_with("P\t")).collect();
     assert_eq!(p_lines.len(), 1);
-    assert_eq!(p_lines[0], &"P\tp1\tid\t*");
+    assert_eq!(p_lines[0], &"P\tp1\tid+\t*");
     assert!(lines.iter().all(|l| !l.starts_with("L\t")));
 
     fs::remove_file(&fasta_path).unwrap();


### PR DESCRIPTION
## Summary
- ensure single sequence path uses orientation markers

## Testing
- `cargo fmt` *(fails: 'cargo-fmt' not installed)*
- `cargo clippy -- -D warnings` *(fails: 'cargo-clippy' not installed)*
- `cargo test` *(fails: could not download crates)*

------
https://chatgpt.com/codex/tasks/task_e_6869e50e8a3c83338a20008e5e1cef3c