### PR TITLE
Replace clone+clear with mem::take

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,9 +40,8 @@ pub mod seqrush {
                 if let Some(id_val) = id.take() {
                     sequences.push(FastaSequence {
                         id: id_val,
-                        data: data.clone(),
+                        data: std::mem::take(&mut data),
                     });
-                    data.clear();
                 }
                 id = Some(line[1..].to_string());
             } else {


### PR DESCRIPTION
## Summary
- avoid allocating when capturing FASTA sequence data

## Testing
- `cargo fmt` *(fails: rustfmt missing)*
- `cargo clippy -- -D warnings` *(fails: clippy missing)*
- `cargo test` *(fails: cannot download crates)*

------
https://chatgpt.com/codex/tasks/task_e_6869e51082188333a755fb77a2429219