### PR TITLE
Remove temporary file cleanup

### DIFF
--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -129,6 +129,9 @@ fn run_seqrush_missing_input() {
     };
     let result = run_seqrush(args);
     assert!(result.is_err());
+    if out_path.exists() {
+        fs::remove_file(out_path).unwrap();
+    }
 }
 
 use std::process::Command;


### PR DESCRIPTION
## Summary
- delete leftover temporary file in `run_seqrush_missing_input` test

## Testing
- `cargo fmt` *(fails: rustfmt missing)*
- `cargo clippy -- -D warnings` *(fails: clippy missing)*
- `cargo test` *(fails: could not download crates)*

------
https://chatgpt.com/codex/tasks/task_e_6869e50820b4833381b21ba1730235ba