### PR TITLE
Clarify CLI build instructions in quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,19 @@ ATCGATGGATCGATCG
 ATCGATCGATCGATGG
 EOF
 
-# Build the pangenome graph
+# Build the project with CLI support
+cargo build --release --features cli
+# Build the pangenome graph using flags
 seqrush -s test.fasta -o test.gfa
 
 # View the output
 cat test.gfa
+```
+
+If you build without `--features cli`, use positional arguments instead:
+
+```bash
+seqrush test.fasta test.gfa
 ```
 
 ## Features


### PR DESCRIPTION
## Summary
- mention building with `--features cli` in quick-start
- describe positional-argument usage when the feature is absent

## Testing
- `cargo clippy -- -D warnings` *(fails: failed to get `clap` as dependency)*
- `cargo test --offline` *(fails: no matching package named `clap` found)*

------
https://chatgpt.com/codex/tasks/task_e_6869f26b9fc0833393d79a787639ffd5