### PR TITLE
Update default docs and fix single path

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Enable the optional `cli` feature to use command-line flags.
 seqrush \
   -s sequences.fasta \        # Input FASTA file
   -o graph.gfa \              # Output GFA file
-  -t 8 \                      # Number of threads (default: 4)
+  -t 8 \                      # Number of threads (default: 1)
   -k 15 \                     # Minimum match length (default: 15)
   --match-score 0 \           # WFA match score (default: 0)
   --mismatch-penalty 5 \      # WFA mismatch penalty (default: 5)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,11 +77,15 @@ pub mod seqrush {
             return Ok(());
         }
 
-        let path_line = sequences
-            .iter()
-            .map(|s| format!("{}+", s.id))
-            .collect::<Vec<_>>()
-            .join(",");
+        let path_line = if sequences.len() == 1 {
+            sequences[0].id.clone()
+        } else {
+            sequences
+                .iter()
+                .map(|s| format!("{}+", s.id))
+                .collect::<Vec<_>>()
+                .join(",")
+        };
         writeln!(file, "P\tp1\t{}\t*", path_line)?;
 
         for window in sequences.windows(2) {


### PR DESCRIPTION
## Summary
- document default thread count as 1
- handle single sequence path without trailing +

## Testing
- `cargo fmt` *(fails: rustfmt not installed)*
- `cargo clippy -- -D warnings` *(fails: clippy not installed)*
- `cargo test --quiet` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6869e4d35b4c8333833da1a1244b6050