### PR TITLE
Add empty FASTA integration test

### DIFF
--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -189,3 +189,22 @@ fn run_seqrush_single_sequence_no_links() {
     assert_eq!(p_lines[0], &"P\tp1\tid+\t*");
     assert!(lines.iter().all(|l| !l.starts_with("L\t")));
 }
+
+#[test]
+fn run_seqrush_empty_input_file() {
+    let fasta_file = temp_file();
+    let gfa_file = temp_file();
+    let args = Args {
+        sequences: fasta_file.path().to_str().unwrap().to_string(),
+        output: gfa_file.path().to_str().unwrap().to_string(),
+        threads: 1,
+        min_match_length: 1,
+    };
+    run_seqrush(args).unwrap();
+
+    let content = fs::read_to_string(gfa_file.path()).unwrap();
+    let lines: Vec<&str> = content.lines().collect();
+    assert_eq!(lines, vec!["H\tVN:Z:1.0"]);
+    assert!(lines.iter().all(|l| !l.starts_with("P\t")));
+    assert!(lines.iter().all(|l| !l.starts_with("L\t")));
+}


### PR DESCRIPTION
## Summary
- verify `run_seqrush` handles empty FASTA input by only writing a GFA header

## Testing
- `cargo clippy -- -D warnings` *(fails: Failure when receiving data from the peer)*
- `cargo test` *(fails: Failure when receiving data from the peer)*

------
https://chatgpt.com/codex/tasks/task_e_6869ff64c1748333b2d5fa4be1a8aadd