### PR TITLE
Add empty FASTA integration test

### DIFF
--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -189,3 +189,22 @@ fn run_seqrush_single_sequence_no_links() {
     assert_eq!(p_lines[0], &"P\tp1\tid+\t*");
     assert!(lines.iter().all(|l| !l.starts_with("L\t")));
 }
+
+#[test]
+fn run_seqrush_empty_input_no_segments_or_paths() {
+    let fasta_file = temp_file();
+    fasta_file.as_file_mut().sync_all().unwrap();
+
+    let gfa_file = temp_file();
+    let args = Args {
+        sequences: fasta_file.path().to_str().unwrap().to_string(),
+        output: gfa_file.path().to_str().unwrap().to_string(),
+        threads: 1,
+        min_match_length: 1,
+    };
+    run_seqrush(args).unwrap();
+
+    let content = fs::read_to_string(gfa_file.path()).unwrap();
+    let lines: Vec<&str> = content.lines().collect();
+    assert_eq!(lines, vec!["H\tVN:Z:1.0"]);
+}


### PR DESCRIPTION
## Summary
- test that seqrush handles empty FASTA input

## Testing
- `cargo clippy -- -D warnings` *(fails: failed to download crates)*
- `cargo test --offline` *(fails: no matching package named `clap` found)*

------
https://chatgpt.com/codex/tasks/task_e_6869ff756a44833385d302336042c3b8