### PR TITLE
Add cli feature tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
             ~/.cargo/git
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Run tests
-        run: cargo test --verbose
+        run: cargo test --features cli
       - name: Generate coverage
         run: |
           cargo install cargo-tarpaulin


### PR DESCRIPTION
## Summary
- run `cargo test --features cli` in workflow
- leave coverage steps after tests

## Testing
- `cargo clippy -- -D warnings` *(fails: failed to download from https://index.crates.io/config.json)*
- `cargo test` *(fails: failed to download from https://index.crates.io/config.json)*

------
https://chatgpt.com/codex/tasks/task_e_6869ff7752d48333bd069a7e2a92c7cb