### PR TITLE
Add invalid output test

### DIFF
--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -118,6 +118,24 @@ fn run_seqrush_missing_input() {
     }
 }
 
+#[test]
+fn run_seqrush_invalid_output_path() {
+    let mut fasta = temp_file();
+    writeln!(fasta, ">id\nACGT").unwrap();
+    fasta.as_file_mut().sync_all().unwrap();
+
+    let dir = tempfile::tempdir().unwrap();
+    let invalid_out = dir.path().join("missing").join("out.gfa");
+    let args = Args {
+        sequences: fasta.path().to_str().unwrap().to_string(),
+        output: invalid_out.to_str().unwrap().to_string(),
+        threads: 1,
+        min_match_length: 1,
+    };
+    let result = run_seqrush(args);
+    assert!(result.is_err());
+}
+
 use std::process::Command;
 
 #[cfg(feature = "cli")]


### PR DESCRIPTION
## Summary
- add integration test verifying `run_seqrush` returns `Err` with invalid output path

## Testing
- `cargo clippy -- -D warnings` *(fails: failed to download crates.io index)*
- `cargo test --quiet` *(fails: failed to download crates.io index)*

------
https://chatgpt.com/codex/tasks/task_e_6869ff7590708333ab9a3b3b939f8bbc