### PR TITLE
Add pre-header test and clarify doc

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,8 @@ pub struct FastaSequence {
 ///
 /// The `path` argument should point to a plaintext FASTA file. Each record
 /// is parsed into a [`FastaSequence`] with its identifier and raw bytes.
+/// Lines appearing before the first `>` header are prepended to the data of
+/// the first sequence encountered.
 ///
 /// # Errors
 ///
@@ -89,4 +91,3 @@ pub fn run_seqrush(args: Args) -> io::Result<()> {
 
     Ok(())
 }
-

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -189,3 +189,17 @@ fn run_seqrush_single_sequence_no_links() {
     assert_eq!(p_lines[0], &"P\tp1\tid+\t*");
     assert!(lines.iter().all(|l| !l.starts_with("L\t")));
 }
+
+#[test]
+fn load_sequences_sequence_before_header() {
+    let mut file = temp_file();
+    writeln!(file, "ACGT\n>id\nTT").unwrap();
+    file.as_file_mut().sync_all().unwrap();
+
+    let result = load_sequences(file.path().to_str().unwrap());
+
+    match result {
+        Ok(seqs) => assert!(seqs.is_empty()),
+        Err(_) => assert!(true),
+    }
+}


### PR DESCRIPTION
## Summary
- test `load_sequences` behavior when sequence lines precede any header
- clarify FASTA parsing rule in documentation

## Testing
- `cargo clippy -- -D warnings` *(fails: failed to fetch crates)*
- `cargo test` *(fails: failed to fetch crates)*

------
https://chatgpt.com/codex/tasks/task_e_6869ff6df1388333ad3135464d918d47