### PR TITLE
Align CI Rust version with rust-toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [stable]
+        rust: ['1.87']
     steps:
       - uses: actions/checkout@v3
       - name: Install Rust


### PR DESCRIPTION
## Summary
- pin the Rust version in CI to `1.87`
- keep the install step using `matrix.rust`

## Testing
- `cargo clippy -- -D warnings` *(fails: failed to download from crates.io)*
- `cargo test` *(fails: failed to download from crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_686a0cb2e52c83339af587bf91aca9bb