### PR TITLE
Update docs for CLI testing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,6 @@ Developers should:
 
 1. Format code using `cargo fmt`.
 2. Run `cargo clippy -- -D warnings`.
-3. Run `cargo test`.
+3. Run `cargo test --features cli`.
 
 Follow these steps before opening a PR.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ seqrush test.fasta test.gfa
 
 ### Prerequisites
 
-- Rust via `rustup` (the required version is pinned in `rust-toolchain.toml`)
+- Rust via `rustup` (install the version pinned in `rust-toolchain.toml` or
+  provide it via an offline setup)
 - Git
 
 ### Build from Source
@@ -162,7 +163,7 @@ L	2	+	3	+	0M
 
 ```bash
 # Run all tests
-cargo test
+cargo test --features cli
 
 # Run with verbose output
 cargo test -- --nocapture


### PR DESCRIPTION
## Summary
- mention installing pinned toolchain locally or via offline setup
- update test instructions to run with `--features cli`

## Testing
- `cargo clippy -- -D warnings` *(fails: failed to download from crates.io)*
- `cargo test --features cli` *(fails: failed to download from crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_686a0cbcd6488333bbeb994a02bb9071