### PR TITLE
Update load_sequences validation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,16 +26,31 @@ pub struct FastaSequence {
 ///
 /// # Errors
 ///
-/// Returns an [`io::Error`] if the file cannot be read.
+/// Returns an [`io::Error`] if the file cannot be read or the first
+/// nonempty line does not start with a FASTA header marker `>`.
 pub fn load_sequences(path: &str) -> io::Result<Vec<FastaSequence>> {
     let file = File::open(path)?;
     let reader = io::BufReader::new(file);
     let mut sequences = Vec::new();
     let mut id = None;
     let mut data: Vec<u8> = Vec::new();
+    let mut checked_first = false;
     for line in reader.lines() {
         let line = line?;
-        if line.starts_with('>') {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        if !checked_first {
+            if !trimmed.starts_with('>') {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "FASTA file must start with '>'",
+                ));
+            }
+            checked_first = true;
+        }
+        if trimmed.starts_with('>') {
             if let Some(id_val) = id.take() {
                 sequences.push(FastaSequence {
                     id: id_val,
@@ -43,9 +58,9 @@ pub fn load_sequences(path: &str) -> io::Result<Vec<FastaSequence>> {
                 });
                 data.clear();
             }
-            id = Some(line[1..].to_string());
+            id = Some(trimmed[1..].to_string());
         } else {
-            data.extend(line.trim().as_bytes());
+            data.extend(trimmed.as_bytes());
         }
     }
     if let Some(id_val) = id {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -95,6 +95,15 @@ fn load_sequences_missing_file() {
 }
 
 #[test]
+fn load_sequences_malformed_first_line() {
+    let mut file = temp_file();
+    writeln!(file, "ACGT\n>id\nTTTT").unwrap();
+    file.as_file_mut().sync_all().unwrap();
+    let result = load_sequences(file.path().to_str().unwrap());
+    assert!(result.is_err());
+}
+
+#[test]
 fn load_sequences_large_input() {
     let mut file = temp_file();
     for i in 0..1000 {


### PR DESCRIPTION
## Summary
- ensure the first nonempty line in a FASTA file starts with '>'
- describe the new error condition in docs
- check malformed input in integration tests

## Testing
- `cargo fmt`
- `cargo clippy -- -D warnings` *(fails: failed to download from crates.io)*
- `cargo test -- --test-threads=1` *(fails: failed to download from crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_686a0cdaea008333910d42ab45b833cf