### PR TITLE
Update README test instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,8 +167,8 @@ cargo test
 # Run with verbose output
 cargo test -- --nocapture
 
-# Run specific test
-cargo test test_performance_scaling
+# Run a specific test
+cargo test run_seqrush_writes_output
 ```
 
 ### Building Documentation


### PR DESCRIPTION
## Summary
- remove nonexistent `test_performance_scaling` example
- show how to run an existing test

## Testing
- `cargo clippy -- -D warnings` *(fails: failed to fetch index)*
- `cargo test -- --nocapture` *(fails: failed to fetch index)*

------
https://chatgpt.com/codex/tasks/task_e_686a0ce509dc833391d6eee35d569a74